### PR TITLE
feat: delete endpoint to revoke course team access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ docs/edx_course_team_api.*.rst
 # Private requirements
 requirements/private.in
 requirements/private.txt
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -34,6 +34,39 @@ Sample response
 }
 ```
 
+### Remove course team member
+
+`DELETE /course-team/<course_key>/modify_access`
+
+The JSON body requires two parameters.
+
+-   `email`: An existed user.
+-   `role`: One of `staff`, `instructor`.
+
+Sample request
+
+```json
+{
+    "email": "instructor@example.com",
+    "role": "instructor"
+}
+```
+
+Sample response
+
+```json
+{
+    "message": "User is removed from course-v1:IBMDeveloperSkillsNetwork+CB0103EN+v1333."
+}
+```
+
+If the user doesn't have the role that was specified in the params
+```json
+{
+    "error": "User does not have role 'instructor' in course 'course-v1:IBMDeveloperSkillsNetwork+CB0103EN+v1333'"
+}
+```
+
 ## Implementation
 
 The handler is taken from [edx/edx-platform/cms/djangoapps/contentstore/views/user.py](https://github.com/edx/edx-platform/blob/d9a072af26ddb87295aa450bea384bc643ad0e50/cms/djangoapps/contentstore/views/user.py#L102-L198).

--- a/README.md
+++ b/README.md
@@ -38,17 +38,15 @@ Sample response
 
 `DELETE /course-team/<course_key>/modify_access`
 
-The JSON body requires two parameters.
+The JSON body requires one paramter.
 
 -   `email`: An existed user.
--   `role`: One of `staff`, `instructor`.
 
 Sample request
 
 ```json
 {
     "email": "instructor@example.com",
-    "role": "instructor"
 }
 ```
 
@@ -60,12 +58,6 @@ Sample response
 }
 ```
 
-If the user doesn't have the role that was specified in the params
-```json
-{
-    "error": "User does not have role 'instructor' in course 'course-v1:IBMDeveloperSkillsNetwork+CB0103EN+v1333'"
-}
-```
 
 ## Implementation
 

--- a/edx_course_team_api/views.py
+++ b/edx_course_team_api/views.py
@@ -10,9 +10,9 @@ from rest_framework.permissions import IsAuthenticated
 from django.contrib.auth.models import User
 
 # edx imports
-from student import auth
-from student.models import CourseEnrollment
-from student.roles import CourseInstructorRole, CourseStaffRole
+from common.djangoapps.student import auth
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from opaque_keys.edx.keys import CourseKey
 from cms.djangoapps.contentstore.views.user import _course_team_user
 
@@ -27,6 +27,17 @@ ROLE_TYPE_MAPPINGS = {
 }
 ROLE_OPTIONS = list(ROLE_TYPE_MAPPINGS.keys())
 
+def validate_param_exist(param, type):
+    if not param:
+        msg = { "error": "Missing parameter '{}' in body.".format(type)}
+        log.info(msg)
+        raise ParseError(msg)
+
+def validate_param_value(param, options):
+    if param not in options:
+        msg = { "error": "Parameter 'role' has to be one of '{}'".format(options) }
+        log.info(msg)
+        raise ParseError(msg)
 class CourseView(APIView):
 
     authentication_classes = [BasicAuthentication]
@@ -36,21 +47,12 @@ class CourseView(APIView):
         course_key = CourseKey.from_string(course_key_string)
 
         email = request.data.get("email", None)
-        if not email:
-            msg = { "error": "Missing parameter 'email' in body." }
-            log.info(msg)
-            raise ParseError(msg)
+        validate_param_exist(email, "email")
 
         role = request.data.get("role", None)
-        if not role:
-            msg = { "error": "Missing parameter 'role' in body." }
-            log.info(msg)
-            raise ParseError(msg)
+        validate_param_exist(role, "role")
 
-        if role not in ROLE_OPTIONS:
-            msg = { "error": "Parameter 'role' has to be one of '{}'".format(ROLE_OPTIONS) }
-            log.info(msg)
-            raise ParseError(msg)
+        validate_param_value(role, ROLE_OPTIONS)
 
         try:
             user = User.objects.get(email=email)
@@ -68,3 +70,39 @@ class CourseView(APIView):
         log.info(msg)
 
         return Response({'message': "User is added to {}.".format(course_key)})
+
+
+    def delete(self, request, course_key_string):
+        course_key = CourseKey.from_string(course_key_string)
+
+        email = request.data.get("email", None)
+        validate_param_exist(email, "email")
+
+        role = request.data.get("role", None)
+        validate_param_exist(role, "role")
+
+        validate_param_value(role, ROLE_OPTIONS)
+
+        try:
+            user = User.objects.get(email=email)
+        except Exception:  # pylint: disable=broad-except
+            msg = {
+                "error": "Could not find user by email address '{email}'".format(email=email)
+            }
+            return Response(msg, 404)
+
+        role_type = ROLE_TYPE_MAPPINGS.get(role)(course_key)
+        if role_type.has_user(request.user):
+            msg = {
+                "error": "User does not have role '{role}' in course '{course_key}'".format(role=role, course_key=course_key)
+            }
+            return Response(msg, 404)
+        auth.get_user_permissions(request.user, course_key)
+
+        auth.remove_users(request.user, role_type, user)
+        CourseEnrollment.unenroll(user, course_key)
+
+        msg = "'{email}' is removed '{role}' from '{course_key}'".format(email=email, role=role, course_key=course_key)
+        log.info(msg)
+
+        return Response({'message': "User is removed from {}.".format(course_key)})


### PR DESCRIPTION
- added `DELETE` method to endpoint `${STUDIO_URL}/sn-api/course-team/<course_key>/modify_access` to remove course team members from a course
