### PR TITLE
Fix 22 Django CVEs: raise minimum to Django 5.2.15

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,5 @@
 -c constraints.txt
 
 
-Django>=5.2.15            # Web application framework
+Django>=5.2.15,<6.0.0     # Web application framework
 djangorestframework>=3.9

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,5 @@
 -c constraints.txt
 
 
-Django>=1.11              # Web application framework
+Django>=5.2.15            # Web application framework
 djangorestframework>=3.9

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,10 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# Django 5.2.15 is the minimum that resolves the 22 CVEs reported by Mend
+# against django 5.2.7 (issue #11), including the SQL injection in
+# QuerySet.filter()/exclude()/get() and Q() (CVE-2025-64459, CVSS 9.1) and the
+# GenericInlineModelAdmin permission bypass (CVE-2026-4277, CVSS 9.8).
+# 5.2.x is the current LTS line; bump as new security releases land.
+Django>=5.2.15

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,12 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# Django 5.2.15 is the minimum that resolves the 22 CVEs reported by Mend
-# against django 5.2.7 (issue #11), including the SQL injection in
-# QuerySet.filter()/exclude()/get() and Q() (CVE-2025-64459, CVSS 9.1) and the
-# GenericInlineModelAdmin permission bypass (CVE-2026-4277, CVSS 9.8).
-# 5.2.x is the current LTS line. The upper bound keeps us on the 5.x series
-# and prevents an unintended major-version jump to 6.0; bump as new security
-# releases land.
-Django>=5.2.15,<6.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,5 +12,7 @@
 # against django 5.2.7 (issue #11), including the SQL injection in
 # QuerySet.filter()/exclude()/get() and Q() (CVE-2025-64459, CVSS 9.1) and the
 # GenericInlineModelAdmin permission bypass (CVE-2026-4277, CVSS 9.8).
-# 5.2.x is the current LTS line; bump as new security releases land.
-Django>=5.2.15
+# 5.2.x is the current LTS line. The upper bound keeps us on the 5.x series
+# and prevents an unintended major-version jump to 6.0; bump as new security
+# releases land.
+Django>=5.2.15,<6.0.0


### PR DESCRIPTION
## Summary

Resolves all 22 dependency vulnerabilities reported by Mend in **issue #11** (`django-5.2.7`, highest severity 9.8). Every CVE in that report is remediated by a single Django upgrade.

The repo only declared `Django>=1.11` in `requirements/base.in`, so the dependency resolver kept landing on a vulnerable build. This raises the floor to **`Django>=5.2.15`**, the current 5.2 **LTS** patch — staying on the same major/LTS line that Mend resolved (5.2.x), so no breaking 6.0 jump.

## Highlights of what this fixes

| CVE | Severity | Issue |
| --- | --- | --- |
| CVE-2026-4277 | Critical (9.8) | `GenericInlineModelAdmin` add-permission bypass on forged POST |
| CVE-2025-64459 | Critical (9.1) | SQL injection via `QuerySet.filter()/exclude()/get()` & `Q()` `_connector` |
| + 20 more | High → Low | all patched in ≤ 5.2.15 |

## Changes
- `requirements/base.in` — `Django>=1.11` → `Django>=5.2.15`
- `requirements/constraints.txt` — documented the pin rationale and the two critical CVEs

## Verification
- `5.2.15` is the latest 5.2 LTS release on PyPI and is `>=` the fix-resolution version of every CVE in the report.
- No application code references a Django version; the only change needed is the dependency floor.

Resolves #11